### PR TITLE
Api issue with latest version of librosa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # torch>=1.5.1
 # torchvision>=0.6.1
 tqdm>=4.30
-librosa>=0.6.3
+librosa>=0.6.3,<0.9
 opencv_python>=4.2.0


### PR DESCRIPTION
Not sure if my local setup is to blame for this but I needed to downgrade librosa to use a pre 0.9 version to avoid the following error
```
loading model... done
loading wave source... Traceback (most recent call last):
  File "/home/cruisibesares/Downloads/vocal-remover/inference.py", line 172, in <module>
    main()
  File "/home/cruisibesares/Downloads/vocal-remover/inference.py", line 133, in main
    X, sr = librosa.load(
TypeError: load() takes 1 positional argument but 3 positional arguments (and 2 keyword-only arguments) were given
```
Changing the requirements.txt got me working. Cool Project thanks for putting this out there.