### PR TITLE
Updated librosa function calls that do not comply to PEP3102

### DIFF
--- a/augment.py
+++ b/augment.py
@@ -47,9 +47,9 @@ if __name__ == '__main__':
             continue
 
         X, _ = librosa.load(
-            mix_path, args.sr, False, dtype=np.float32, res_type='kaiser_fast')
+            mix_path, sr=args.sr, mono=False, dtype=np.float32, res_type='kaiser_fast')
         y, _ = librosa.load(
-            inst_path, args.sr, False, dtype=np.float32, res_type='kaiser_fast')
+            inst_path, sr=args.sr, mono=False, dtype=np.float32, res_type='kaiser_fast')
 
         X, y = spec_utils.align_wave_head_and_tail(X, y, args.sr)
         v = X - y
@@ -60,9 +60,9 @@ if __name__ == '__main__':
         subprocess.call(cmd_v, stderr=subprocess.DEVNULL)
 
         y, _ = librosa.load(
-            output_i, args.sr, False, dtype=np.float32, res_type='kaiser_fast')
+            output_i, sr=args.sr, mono=False, dtype=np.float32, res_type='kaiser_fast')
         v, _ = librosa.load(
-            output_v, args.sr, False, dtype=np.float32, res_type='kaiser_fast')
+            output_v, sr=args.sr, mono=False, dtype=np.float32, res_type='kaiser_fast')
 
         X = y + v
 

--- a/inference.py
+++ b/inference.py
@@ -136,7 +136,7 @@ def main():
 
     print('loading wave source...', end=' ')
     X, sr = librosa.load(
-        args.input, args.sr, False, dtype=np.float32, res_type='kaiser_fast')
+        args.input, sr=args.sr, mono=False, dtype=np.float32, res_type='kaiser_fast')
     basename = os.path.splitext(os.path.basename(args.input))[0]
     print('done')
 

--- a/lib/spec_utils.py
+++ b/lib/spec_utils.py
@@ -27,8 +27,8 @@ def wave_to_spectrogram(wave, hop_length, n_fft):
     wave_left = np.asfortranarray(wave[0])
     wave_right = np.asfortranarray(wave[1])
 
-    spec_left = librosa.stft(wave_left, n_fft, hop_length=hop_length)
-    spec_right = librosa.stft(wave_right, n_fft, hop_length=hop_length)
+    spec_left = librosa.stft(wave_left, n_fft=n_fft, hop_length=hop_length)
+    spec_right = librosa.stft(wave_right, n_fft=n_fft, hop_length=hop_length)
     spec = np.asfortranarray([spec_left, spec_right])
 
     return spec
@@ -152,9 +152,9 @@ def cache_or_load(mix_path, inst_path, sr, hop_length, n_fft):
         y = np.load(inst_cache_path)
     else:
         X, _ = librosa.load(
-            mix_path, sr, False, dtype=np.float32, res_type='kaiser_fast')
+            mix_path, sr=sr, mono=False, dtype=np.float32, res_type='kaiser_fast')
         y, _ = librosa.load(
-            inst_path, sr, False, dtype=np.float32, res_type='kaiser_fast')
+            inst_path, sr=sr, mono=False, dtype=np.float32, res_type='kaiser_fast')
 
         X, y = align_wave_head_and_tail(X, y, sr)
 
@@ -196,9 +196,9 @@ if __name__ == "__main__":
     ], axis=0) * 0.2
 
     X, _ = librosa.load(
-        sys.argv[1], 44100, False, dtype=np.float32, res_type='kaiser_fast')
+        sys.argv[1], sr=44100, mono=False, dtype=np.float32, res_type='kaiser_fast')
     y, _ = librosa.load(
-        sys.argv[2], 44100, False, dtype=np.float32, res_type='kaiser_fast')
+        sys.argv[2], sr=44100, mono=False, dtype=np.float32, res_type='kaiser_fast')
 
     X, y = align_wave_head_and_tail(X, y, 44100)
     X_spec = wave_to_spectrogram(X, 1024, 2048)


### PR DESCRIPTION
### tl; dr
I updated `librosa.load`, `librosa.stft`, and `librosa.istft` to specify keywords after the first positional argument (because librosa >= 0.9 complies with PEP3102)

## Summary
In reference to #123 and #124, that get the error `load() takes 1 positional argument but 3 positional arguments (and 2 keyword-only arguments) were given`

If you use the tool on Google Colab 2023 (where `pip freeze` displays `librosa==0.10.0.post2`), librosa>=0.9 updated their function calls to comply with PEP3102, where anything past an asterisk is "keyword-only." 