### PR TITLE
Fix: .pth from any folder

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -104,11 +104,13 @@ class Separator(object):
 
         return y_spec, v_spec
 
+MODEL_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'models')
+DEFAULT_MODEL_PATH = os.path.join(MODEL_DIR, 'baseline.pth')
 
 def main():
     p = argparse.ArgumentParser()
     p.add_argument('--gpu', '-g', type=int, default=-1)
-    p.add_argument('--pretrained_model', '-P', type=str, default=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'models/baseline.pth'))
+    p.add_argument('--pretrained_model', '-P', type=str, default=DEFAULT_MODEL_PATH)
     p.add_argument('--input', '-i', required=True)
     p.add_argument('--sr', '-r', type=int, default=44100)
     p.add_argument('--n_fft', '-f', type=int, default=2048)

--- a/inference.py
+++ b/inference.py
@@ -108,7 +108,7 @@ class Separator(object):
 def main():
     p = argparse.ArgumentParser()
     p.add_argument('--gpu', '-g', type=int, default=-1)
-    p.add_argument('--pretrained_model', '-P', type=str, default='models/baseline.pth')
+    p.add_argument('--pretrained_model', '-P', type=str, default=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'models/baseline.pth'))
     p.add_argument('--input', '-i', required=True)
     p.add_argument('--sr', '-r', type=int, default=44100)
     p.add_argument('--n_fft', '-f', type=int, default=2048)


### PR DESCRIPTION
Related to issue #117 , you cannot found the .pth if you're not in the same folder as `inference.py`. This commit fix this issue.