### PR TITLE
Add resampy to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 tqdm>=4.30
 librosa>=0.9
 opencv_python>=4.2.0
+resampy


### PR DESCRIPTION
When I tried installing vocal-remover, I discovered that resampy isn't included in the requirements.txt, which is required by vocal-remover.